### PR TITLE
Changes to make PDF optional and allow install from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pdfminer/
 _exceptions.log
 __pycache__
 .ipynb_checkpoints
+pybrl.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "pybrl"
+version = "0.1.0"
+description = "A Grade-2 Braille Translation system written entirely in Python"
+readme = "README.md"
+requires-python = ">=3.5"
+license = {file = "LICENSE"}
+keywords = ["braille"]
+
+authors = [
+  { name = "Antonis Katzourakis" }
+]
+maintainers = [
+  { name = "Antonis Katzourakis" }
+]
+
+classifiers = [
+  # How mature is this project? Common values are
+  #   3 - Alpha
+  #   4 - Beta
+  #   5 - Production/Stable
+  "Development Status :: 4 - Beta",
+
+  # Audience
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+
+  # Supported Python version
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.5",
+  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+dependencies = [
+  "asciimathml ~= 0.9.5.1",
+  "six"
+]
+
+[tool.setuptools]
+packages = [
+  "languages",
+  "brl_mathematics"
+]
+
+[project.optional-dependencies]
+pdf = ["pdfminer==20140328"]
+
+[project.urls]
+"Homepage" = "https://github.com/ant0nisk/pybrl/blob/master/README.md"
+"Bug Reports" = "https://github.com/ant0nisk/pybrl/issues"
+"Source" = "https://github.com/ant0nisk/pybrl"
+
+[build-system]
+requires = ["setuptools>=43.0.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 
 [tool.setuptools]
 packages = [
+  "pybrl",
   "languages",
   "brl_mathematics"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ dependencies = [
 
 [tool.setuptools]
 packages = [
-  "pybrl",
+  "utils",
   "languages",
   "brl_mathematics"
 ]
+py-modules = ["pybrl"]
 
 [project.optional-dependencies]
 pdf = ["pdfminer==20140328"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
 try:
     from . import pdf_utils
 except:
-    print("pdf_utils module not found, this funcationality will be disabled.")
+    print("pdf_utils module not found, PDF funcationality will be disabled.")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,4 @@
-from . import pdf_utils
+try:
+    from . import pdf_utils
+except:
+    print("pdf_utils module not found, this funcationality will be disabled.")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
 try:
     from . import pdf_utils
 except:
-    print("pdf_utils module not found, PDF funcationality will be disabled.")
+    print("Warning: pdf_utils module not found, PDF funcationality will be disabled.")


### PR DESCRIPTION
Feel free to just close this PR if it does not fit for this project.

* Adds a `pyproject.toml` file so that the package is installable from via pip and git: `pip install git+https://github.com/jmwright/pybrl.git`. This should also make the project easier to publish on PyPi.
* Makes the `pdfminer` installation optional (only when using pip) and skips the `pdf_utils` import if it is not present (but still warns the user). The version of `pdfminer` specified in `requirements.txt` causes issues with newer versions of Python. It might be possible to use a newer version of `pdfminer`, but I do not need that functionality so I did not check into it.
* Seems to work fine on Python 3.10. It should also work with 3.11, but I did not check that.